### PR TITLE
Add support for URI parameters members

### DIFF
--- a/src/Elements/HrefVariablesElement.php
+++ b/src/Elements/HrefVariablesElement.php
@@ -15,7 +15,6 @@ class HrefVariablesElement extends BaseElement implements ApiElement, ApiHrefVar
             $memberContent = $member->getContent();
 
             $hrefVariable = new HrefVariable();
-            $hrefVariable->dataType = $memberContent['value']['element'];
             $hrefVariable->description = $member->getMetaData()['description'];
             $hrefVariable->name = $memberContent['key']['content'];
 
@@ -26,11 +25,28 @@ class HrefVariablesElement extends BaseElement implements ApiElement, ApiHrefVar
                 $hrefVariable->required = 'optional';
             }
 
-            if (isset($memberContent['value']['content'])) {
-                $hrefVariable->example = $memberContent['value']['content'];
-            }
+            $dataType = $memberContent['value']['element'];
+            if ($dataType === 'enum' && isset($memberContent['value']['content'])) {
+                $hrefVariable->dataType = $memberContent['value']['content'][0]['element'];
+                $hrefVariable->values = array_map(function($v) {
+                    return is_object($v) ? $v->content : $v['content'];
+                }, $memberContent['value']['content']);
 
-            if (isset($memberContent['value']['attributes'])) {
+                if (isset($memberContent['value']['attributes']['samples'])) {
+                    $hrefVariable->example = $memberContent['value']['attributes']['samples'][0][0]['content'];
+                }
+
+                if (isset($memberContent['value']['attributes']['default'])) {
+                    $hrefVariable->default = $memberContent['value']['attributes']['default'][0]['content'];
+                }
+            } else {
+                $hrefVariable->dataType = $dataType;
+                $hrefVariable->values = [];
+
+                if (isset($memberContent['value']['content'])) {
+                    $hrefVariable->example = $memberContent['value']['content'];
+                }
+
                 if (isset($memberContent['value']['attributes']['default'])) {
                     $hrefVariable->default = $memberContent['value']['attributes']['default'];
                 }

--- a/src/Value/HrefVariable.php
+++ b/src/Value/HrefVariable.php
@@ -10,4 +10,5 @@ class HrefVariable
     public $dataType;
     public $required;
     public $description;
+    public $values;
 }

--- a/tests/Parser/RefractParserTest.php
+++ b/tests/Parser/RefractParserTest.php
@@ -332,7 +332,7 @@ class RefractParserTest extends \PHPUnit_Framework_TestCase
         /** All My Messages */
         /** @var ResourceElement $resource */
         $resource = $resources[1];
-        $this->assertSame('/messages{?limit}', $resource->getHref());
+        $this->assertSame('/messages{?limit,type}', $resource->getHref());
 
         /** @var HttpTransitionElement $transition */
         $transition = $resource->getTransitions()[0];
@@ -348,6 +348,17 @@ class RefractParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('number', $hrefVariable->dataType);
         $this->assertSame('optional', $hrefVariable->required);
         $this->assertSame('The maximum number of results to return.', $hrefVariable->description);
+        $this->assertEmpty($hrefVariable->values);
+
+        /** @var HrefVariable $hrefVariable */
+        $hrefVariable = array_shift($hrefVariableObjects);
+        $this->assertSame('type', $hrefVariable->name);
+        $this->assertSame('unread', $hrefVariable->example);
+        $this->assertSame('all', $hrefVariable->default);
+        $this->assertSame('string', $hrefVariable->dataType);
+        $this->assertSame('optional', $hrefVariable->required);
+        $this->assertSame('The type of messages to return.', $hrefVariable->description);
+        $this->assertEquals(['all', 'unread', 'read'], $hrefVariable->values);
     }
 
     public function Attributes(Parser $parser, $fixture)

--- a/tests/fixtures/07. Parameters.md
+++ b/tests/fixtures/07. Parameters.md
@@ -16,7 +16,7 @@ communicating with our API about messages.
 Group of all messages-related resources.
 
 ## My Message [/message/{id}]
-Here we have added the message `id` parameter as an 
+Here we have added the message `id` parameter as an
 [URI Template variable](http://tools.ietf.org/html/rfc6570) in the Message
 resource's URI. Note the parameter name `id` is enclosed in curly brackets. We
 will discuss this parameter in the `Parameters` section below, where we will
@@ -75,7 +75,7 @@ also set its example value to `1` and declare it of an arbitrary 'number' type.
 
 + Response 204
 
-## All My Messages [/messages{?limit}]
+## All My Messages [/messages{?limit,type}]
 A resource representing all of my messages in the system.
 
 We have added the query URI template parameter - `limit`. This parameter is
@@ -87,8 +87,14 @@ we will discuss it only at the particular action level below.
 
 + Parameters
 
-    + limit (number, optional) - The maximum number of results to return.
+    + limit: (number, optional) - The maximum number of results to return.
         + Default: `20`
+    + type: `unread` (enum[string], optional) - The type of messages to return.
+        + Default: `all`
+        + Members
+          + `all`
+          + `unread`
+          + `read`
 
 + Response 200 (application/json)
 

--- a/tests/fixtures/07. Parameters.md.refract.json
+++ b/tests/fixtures/07. Parameters.md.refract.json
@@ -381,7 +381,7 @@
                 "title": "All My Messages"
               },
               "attributes": {
-                "href": "/messages{?limit}"
+                "href": "/messages{?limit,type}"
               },
               "content": [
                 {
@@ -417,6 +417,56 @@
                               "attributes": {
                                 "default": "20"
                               }
+                            }
+                          }
+                        },
+                        {
+                          "element": "member",
+                          "meta": {
+                            "description": "The type of messages to return."
+                          },
+                          "attributes": {
+                            "typeAttributes": [
+                              "optional"
+                            ]
+                          },
+                          "content": {
+                            "key": {
+                              "element": "string",
+                              "content": "type"
+                            },
+                            "value": {
+                              "element": "enum",
+                              "attributes": {
+                                "samples": [
+                                  [
+                                    {
+                                      "element": "string",
+                                      "content": "unread"
+                                    }
+                                  ]
+                                ],
+                                "default": [
+                                  {
+                                    "element": "string",
+                                    "content": "all"
+                                  }
+                                ]
+                              },
+                              "content": [
+                                {
+                                  "element": "string",
+                                  "content": "all"
+                                },
+                                {
+                                  "element": "string",
+                                  "content": "unread"
+                                },
+                                {
+                                  "element": "string",
+                                  "content": "read"
+                                }
+                              ]
                             }
                           }
                         }


### PR DESCRIPTION
I have found (and fixed) an inconsistency with the API Blueprint specification namely support for the URI parameters' Members item.

> `Members` is the optional enumeration of possible values. `<type>` should be surrounded by `enum[]` if this is present.

[API Blueprint Specification - URI parameters section](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#def-uriparameters-section)

Thanks for the work you have put into this package! I'm using it to build an API Blueprint renderer for the Laravel framework. Credits will be given. :)