### PR TITLE
Add support for URI parameters members

### DIFF
--- a/src/Elements/HrefVariablesElement.php
+++ b/src/Elements/HrefVariablesElement.php
@@ -15,7 +15,6 @@ class HrefVariablesElement extends BaseElement implements ApiElement, ApiHrefVar
             $memberContent = $member->getContent();
 
             $hrefVariable = new HrefVariable();
-            $hrefVariable->dataType = $memberContent['value']['element'];
             $hrefVariable->description = $member->getMetaData()['description'];
             $hrefVariable->name = $memberContent['key']['content'];
 
@@ -26,11 +25,28 @@ class HrefVariablesElement extends BaseElement implements ApiElement, ApiHrefVar
                 $hrefVariable->required = 'optional';
             }
 
-            if (isset($memberContent['value']['content'])) {
-                $hrefVariable->example = $memberContent['value']['content'];
-            }
+            $dataType = $memberContent['value']['element'];
+            if ($dataType === 'enum' && isset($memberContent['value']['content'])) {
+                $hrefVariable->dataType = $memberContent['value']['content'][0]['element'];
+                $hrefVariable->values = array_map(function($v) {
+                    return is_object($v) ? $v->content : $v['content'];
+                }, $memberContent['value']['content']);
 
-            if (isset($memberContent['value']['attributes'])) {
+                if (isset($memberContent['value']['attributes']['samples'])) {
+                    $hrefVariable->example = $memberContent['value']['attributes']['samples'][0][0]['content'];
+                }
+
+                if (isset($memberContent['value']['attributes']['default'])) {
+                    $hrefVariable->default = $memberContent['value']['attributes']['default'][0]['content'];
+                }
+            } else {
+                $hrefVariable->dataType = $dataType;
+                $hrefVariable->values = [];
+
+                if (isset($memberContent['value']['content'])) {
+                    $hrefVariable->example = $memberContent['value']['content'];
+                }
+
                 if (isset($memberContent['value']['attributes']['default'])) {
                     $hrefVariable->default = $memberContent['value']['attributes']['default'];
                 }

--- a/src/Value/HrefVariable.php
+++ b/src/Value/HrefVariable.php
@@ -10,4 +10,5 @@ class HrefVariable
     public $dataType;
     public $required;
     public $description;
+    public $values;
 }


### PR DESCRIPTION
I have found (and fixed) an inconsistency with the API Blueprint specification namely support for URI parameter Members.

> `Members` is the optional enumeration of possible values. `<type>` should be surrounded by `enum[]` if this is present.

[API Blueprint Specification - URI parameters section](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#def-uriparameters-section)

As I described in my [previous pull request](https://github.com/hendrikmaus/reynaldo/pull/2), this feature can't be tested with the method you use so far (pulling the fixtures from apiaryio/api-blueprint) because non of their examples actually use these member values, even though they are part of the [official specs](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#def-uriparameters-section). I could add an additional custom fixture specifically to test this feature but I like to hear your opinion first.

As I wrote before, thanks a lot for the work you have put into this package! I'm using it in [Blueprint Docs](https://github.com/M165437/laravel-blueprint-docs), an API Blueprint Renderer for the Laravel framework I just released. I have given you credit in the README.md file.

I hope to hear from you!