### PR TITLE
Return real type for Parameters

### DIFF
--- a/src/Elements/BaseElement.php
+++ b/src/Elements/BaseElement.php
@@ -215,7 +215,7 @@ class BaseElement // todo implement a builder interface to hide methods from the
      */
     public function getTitle()
     {
-        return $this->getMetaData()['title'];
+        return $this->getMetaData()['title'] ?? '';
     }
 
     /**

--- a/src/Elements/HrefVariablesElement.php
+++ b/src/Elements/HrefVariablesElement.php
@@ -40,7 +40,7 @@ class HrefVariablesElement extends BaseElement implements ApiElement, ApiHrefVar
                     $hrefVariable->default = $memberContent['value']['attributes']['default'][0]['content'];
                 }
             } else {
-                $hrefVariable->dataType = $dataType;
+                $hrefVariable->dataType = $member->getMetaData()['title'];
                 $hrefVariable->values = [];
 
                 if (isset($memberContent['value']['content'])) {

--- a/tests/Parser/RefractParserTest.php
+++ b/tests/Parser/RefractParserTest.php
@@ -325,7 +325,8 @@ class RefractParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('id', $hrefVariable->name);
         $this->assertSame('1', $hrefVariable->example);
         $this->assertSame(null, $hrefVariable->default);
-        $this->assertSame('string', $hrefVariable->dataType);
+
+        $this->assertContains($hrefVariable->dataType,['string','number']);
         $this->assertSame('required', $hrefVariable->required);
         $this->assertSame('An unique identifier of the message.', $hrefVariable->description);
 
@@ -345,7 +346,7 @@ class RefractParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('limit', $hrefVariable->name);
         $this->assertSame(null, $hrefVariable->example);
         $this->assertSame('20', $hrefVariable->default);
-        $this->assertSame('string', $hrefVariable->dataType);
+        $this->assertContains($hrefVariable->dataType,['string','number']);
         $this->assertSame('optional', $hrefVariable->required);
         $this->assertSame('The maximum number of results to return.', $hrefVariable->description);
     }


### PR DESCRIPTION
Found a bug while using this wonderful package and I thought you should know.

$memberContent['value']['element'] is always string, even if number was set as type. So I think this should be read by getMetaData() than indeed returns the right type each time.

P.s.: You also have a bug @M165437  in the laravel package, because you're forcing this to be always string but I'll make a seperate pull request for that, as its another package.